### PR TITLE
adding paradigm_tools.py

### DIFF
--- a/examples.rst
+++ b/examples.rst
@@ -89,6 +89,8 @@ be used for testing.
 <BLANKLINE>
 <BLANKLINE>
 
+>>> inflexion.conjugate_core("λύω", "PAI", "AAI", tags={"final-nu-aai.3s"})
+[('PAI', {'PAI.1S': 'λῡ́ω', 'PAI.2S': 'λῡ́εις', 'PAI.3S': 'λῡ́ει', 'PAI.1P': 'λῡ́ομεν', 'PAI.2P': 'λῡ́ετε', 'PAI.3P': 'λῡ́ουσι(ν)'}), ('AAI', {'AAI.1S': 'ἔλυσα', 'AAI.2S': 'ἔλυσας', 'AAI.3S': 'ἔλυσε(ν)', 'AAI.1P': 'ἐλύσαμεν', 'AAI.2P': 'ἐλύσατε', 'AAI.3P': 'ἔλυσαν'})]
 
 >>> inflexion.decline("λύω", "PAP")
 -
@@ -127,4 +129,115 @@ be used for testing.
     PAP.DPN: λῡ́ουσι(ν)
     PAP.APN: λῡ́οντα
 <BLANKLINE>
+<BLANKLINE>
+
+# `paradigm_tools.py`
+
+`paradigm_tools.py` defines a few functions that use `greek-inflexion` to generate paradigms in either `html` or `markdown`.
+
+For verbs use:
+
+* `conjugate_html`
+* `conjugate_md`
+
+
+
+
+>>> import paradigm_tools as pu
+
+
+>>> pu.conjugate_md("λύω", "PAI", "PMI", tags={"final-nu-aai.3s"}, merge_paradigms=True)
+| ἀριθμός | πρώσοπον | ἐνεστώς ἐνεργητικόν ὁριστική | ἐνεστώς μέσον ὁριστική |
+|:----|:----|:----|:----|
+| ἑνικόν | πρῶτον | λῡ́ω | λῡ́ομαι |
+| | δευτέρον | λῡ́εις | λῡ́ῃ/λῡ́ει |
+| | τρίτον | λῡ́ει | λῡ́εται |
+| πληθυντικόν | πρῶτον | λῡ́ομεν | λῡόμεθα |
+| | δευτέρον | λῡ́ετε | λῡ́εσθε |
+| | τρίτον | λῡ́ουσι(ν) | λῡ́ονται |
+<BLANKLINE>
+
+>>> pu.conjugate_md("λύω", "PAI", "PMI", tags={"final-nu-aai.3s"}, merge_paradigms=False)
+| ἀριθμός | πρώσοπον | ἐνεστώς ἐνεργητικόν ὁριστική |
+|:----|:----|:----|
+| ἑνικόν | πρῶτον | λῡ́ω |
+| | δευτέρον | λῡ́εις |
+| | τρίτον | λῡ́ει |
+| πληθυντικόν | πρῶτον | λῡ́ομεν |
+| | δευτέρον | λῡ́ετε |
+| | τρίτον | λῡ́ουσι(ν) |
+<BLANKLINE>
+| ἀριθμός | πρώσοπον | ἐνεστώς μέσον ὁριστική |
+|:----|:----|:----|
+| ἑνικόν | πρῶτον | λῡ́ομαι |
+| | δευτέρον | λῡ́ῃ/λῡ́ει |
+| | τρίτον | λῡ́εται |
+| πληθυντικόν | πρῶτον | λῡόμεθα |
+| | δευτέρον | λῡ́εσθε |
+| | τρίτον | λῡ́ονται |
+<BLANKLINE>
+
+>>> pu.conjugate_html("λύω", "PAN", "AAN", tags={"final-nu-aai.3s"})
+<link href="./paradigm.css" rel="stylesheet">
+<table class="verb-paradigm">
+<thead><tr class="para-header-row"><td class="para-header-cell"></td><td class="para-header-cell">ἀπαρέμφατος</td></tr></thead><tbody>
+<tr><td class="para-item">ἐνεστώς ἐνεργητικόν</td><td class="para-item">λῡ́ειν</td></tr>
+<tr><td class="para-item">ἀόριστος ἐνεργητικόν</td><td class="para-item">λῦσαι</td></tr>
+</tbody>
+</table>
+<BLANKLINE>
+
+For participels, adjectives, and nouns use:
+
+* `decline_html`
+* `decline_md`
+
+
+>>> pu.decline_md("λύω", "PAP")
+|  ἀριθμός | πτῶσις | ἀρσενικόν | θηλυκόν | οὐδέτερον  |
+|:----|:----|:----|:----|:----|
+| ἑνικόν | ὀνομαστική | λῡ́ων | λῡ́ουσᾰ | λῦον |
+| | γενική | λῡ́οντος | λῡούσης | λῡ́οντος |
+| | δοτική | λῡ́οντι | λῡούσῃ | λῡ́οντι |
+| | αἰτιατική | λῡ́οντα | λῡ́ουσᾰν | λῦον |
+| | κλητική | λῡ́ων | λῡ́ουσᾰ | λῦον |
+| πληθυντικόν | ὀνομαστική | λῡ́οντες | λῡ́ουσαι | λῡ́οντα |
+| | γενική | λῡόντων | λῡουσῶν | λῡόντων |
+| | δοτική | λῡ́ουσι(ν) | λῡούσαις | λῡ́ουσι(ν) |
+| | αἰτιατική | λῡ́οντας | λῡούσᾱς | λῡ́οντα |
+| | κλητική | λῡ́οντες | λῡ́ουσαι | λῡ́οντα |
+<BLANKLINE>
+
+
+In cases where one does not want to use the forms found by `greek-inflexion` the following code can be run. If you want a merged paradigm where all forms are combined in the same table, then run the code below. It expects a list containing the lists for forms to be displayed and a list of column headers for each list. There is also a markdown version of this function called `layout_merged_verb_paradigm_md`. If you want seperate tables for each list, then run `layout_non_merged_verb_paradigm_html` or `layout_non_merged_verb_paradigm_md`. **Note**: this only work for indicative, subjuncitve, and optative.
+
+
+>>> labels = pu.load_labels("labels.yaml", 'el')
+>>> pu.layout_merged_verb_paradigm_html([["1", "2", "3", "4", "5", "6"]], ["Random"], labels)
+<link href="./paradigm.css" rel="stylesheet">
+<table class="verb-paradigm">
+<thead><tr class="para-header-row"><td class="para-header-cell">ἀριθμός</td><td class="para-header-cell">πρώσοπον</td><td class="para-header-cell"></td></tr></thead><tbody>
+<tr><td class="para-row-label" rowspan="3" valign="top">ἑνικόν</td><td class="para-row-label">πρῶτον</td><td class="para-item">1</td></tr>
+<tr><td class="para-row-label">δευτέρον</td><td class="para-item">2</td></tr>
+<tr><td class="para-row-label">τρίτον</td><td class="para-item">3</td></tr>
+<tr><td class="para-row-label" rowspan="3" valign="top">πληθυντικόν</td><td class="para-row-label">πρῶτον</td><td class="para-item">4</td></tr>
+<tr><td class="para-row-label">δευτέρον</td><td class="para-item">5</td></tr>
+<tr><td class="para-row-label">τρίτον</td><td class="para-item">6</td></tr>
+</tbody>
+</table>
+<BLANKLINE>
+
+
+If you want seperate tables for each list, then run `layout_non_merged_verb_paradigm_html` or `layout_non_merged_verb_paradigm_md`. Note that unlike the merged versions, it expects a list of the forms (rather than a list of lists) and a single label (rather than a list of labels).
+
+
+>>> pu.layout_non_merged_verb_paradigm_md(["1", "2", "3", "4", "5", "6"], "Random", labels)
+| ἀριθμός | πρώσοπον |  |
+|:----|:----|:----|
+| ἑνικόν | πρῶτον | 1 |
+| | δευτέρον | 2 |
+| | τρίτον | 3 |
+| πληθυντικόν | πρῶτον | 4 |
+| | δευτέρον | 5 |
+| | τρίτον | 6 |
 <BLANKLINE>

--- a/greek_inflexion.py
+++ b/greek_inflexion.py
@@ -124,6 +124,72 @@ class GreekInflexion:
         print()
         print()
 
+    def conjugate_core(self, lemma, *TVMs, tags=None):
+        result = []
+        for TVM in TVMs:
+            out = {}
+            if TVM[2] in "ISO":
+                for PN in ["1S", "2S", "3S", "1P", "2P", "3P"]:
+                    parse = TVM + "." + PN
+                    form = "/".join(
+                        self.generate(lemma, parse, tags=tags).keys())
+                    if form:
+                        out[parse] = form
+            elif TVM[2] == "D":
+                if "." not in TVM:
+                    for PN in ["2S", "3S", "2P", "3P"]:
+                        parse = TVM + "." + PN
+                        form = "/".join(
+                            self.generate(lemma, parse, tags=tags).keys())
+                        if form:
+                            out[parse] = form
+                else:
+                    form = "/".join(
+                        self.generate(lemma, parse, tags=tags).keys())
+                    if form:
+                        out[parse] = form
+            elif TVM[2] == "N":
+                parse = TVM
+                form = "/".join(
+                    self.generate(lemma, parse, tags=tags).keys())
+                if form:
+                    out[parse] = form
+            elif TVM[2] == "P":
+                if TVM.endswith(".N"):
+                    for NG in ["SM", "SF", "SN"]:
+                        parse = TVM + NG
+                        form = "/".join(
+                            self.generate(lemma, parse, tags=tags).keys())
+                        if form:
+                            out[parse] = form
+                else:
+                    for CNG in ["NSM", "NSF", "NSN", "GSM", "GSF", "GSN"]:
+                        parse = TVM + "." + CNG
+                        form = "/".join(
+                            self.generate(lemma, parse, tags=tags).keys())
+                        if form:
+                            out[parse] = form
+            result.append((TVM, out))
+        return result
+
+    def decline_core(self, lemma, TVM, tags=None):
+        if TVM[2] != "P":
+            raise ValueError
+        result = []
+        for G in "MFN":
+            forms = {}
+            for CN in [
+                "NS", "GS", "DS", "AS", "VS",
+                "NP", "GP", "DP", "AP", "VP"
+            ]:
+                parse = TVM + "." + CN + G
+                form = "/".join(
+                    self.generate(lemma, parse, tags=tags).keys())
+                if form:
+                    forms[parse] = form
+            result.append(forms)
+        return result
+
     def decline(self, lemma, TVM, tags=None):
 
         if TVM[2] != "P":

--- a/labels.yaml
+++ b/labels.yaml
@@ -1,0 +1,58 @@
+en:
+  PL: plural
+  SG: singular
+  pres: present
+  act: active
+  mid: middle
+  pass: passive
+  1st: 1st
+  2nd: 2nd
+  3rd: 3rd
+  case: case
+  masc: M
+  fem: F
+  neut: N
+  nom: nom
+  gen: gen
+  dat: dat
+  acc: acc
+  voc: voc
+  person: person
+  number: number
+  unknown: '' #allows columns to be blank if '' else uses whatever lebel you assign for them
+  AAI: Aorist Active Indicative
+  PAI: Present Active Indicative
+  XAI: perfect active indicative
+  IAI: Imperfect Active Indicative
+  FAI: Future Active Indicative
+  PMI: Present Middle Indicative
+el:
+  PL: πληθυντικόν
+  SG: ἑνικόν
+  act: ἐνεργητικόν
+  mid: μέσον
+  pass: παθητικόν
+  person: πρώσοπον
+  1st: πρῶτον
+  2nd: δευτέρον
+  3rd: τρίτον
+  number: ἀριθμός
+  masc: ἀρσενικόν
+  fem: θηλυκόν
+  neut: οὐδέτερον
+  case: πτῶσις
+  nom: ὀνομαστική
+  gen: γενική
+  dat: δοτική
+  acc: αἰτιατική
+  voc: κλητική
+  inf: ἀπαρέμφατος
+  unknown: '' #allows columns to be blank if '' else uses whatever lebel you assign for them
+  AAI: ἀόριστος ἐνεργητικόν ὁριστική
+  PAI: ἐνεστώς ἐνεργητικόν ὁριστική
+  XAI: παρακείμενος ἐνεργητικόν ὁριστική
+  IAI: παρατατικός ἐνεργητικόν ὁριστική
+  FAI: μέλλων ἐνεργητικόν ὁριστική
+  PMI: ἐνεστώς μέσον ὁριστική
+  PAN: ἐνεστώς ἐνεργητικόν
+  AAN: ἀόριστος ἐνεργητικόν

--- a/paradigm.css
+++ b/paradigm.css
@@ -1,0 +1,13 @@
+.para-header-row { }
+.para-header-cell {margin-bottom:3em; border-bottom: solid 0.125em black;}
+
+.para-row-label {margin-right:1.25em;}
+
+table {
+    border-collapse: collapse;
+}
+
+td {
+  font-size: 1.25em;
+  padding:0.25em;
+}

--- a/paradigm.css
+++ b/paradigm.css
@@ -1,7 +1,7 @@
 .para-header-row { }
-.para-header-cell {margin-bottom:3em; border-bottom: solid 0.125em black;}
+.para-header-cell {margin-bottom:3em; border-bottom: solid 0.125em black; word-wrap: normal; max-width: 92px;}
 
-.para-row-label {margin-right:1.25em;}
+.para-row-label {padding-right:1.25em; word-wrap: normal; max-width: 94px;}
 
 table {
     border-collapse: collapse;

--- a/paradigm_tools.py
+++ b/paradigm_tools.py
@@ -1,14 +1,10 @@
 # py -m doctest -v examples.rst
 from greek_inflexion import GreekInflexion
-import pprint
-
-
-
-from yaml import load, dump
+from yaml import load
 try:
-    from yaml import CLoader as Loader, CDumper as Dumper
+    from yaml import CLoader as Loader
 except ImportError:
-    from yaml import Loader, Dumper
+    from yaml import Loader
 
 inflexion = GreekInflexion('stemming.yaml', 'STEM_DATA/pratt_lexicon.yaml')
 
@@ -30,17 +26,14 @@ def layout_merged_imp_paradigm_md(verbs, TVMs, labels):
     verbs = [[f' {y} ' for y in xs] for xs in verbs]
     row_labels = [f' {labels[x]} ' for x in ['2nd', '3rd']] * 2
     verbs.insert(0,row_labels)
-    sgpl = [f' {labels["SG"]} ',  ' ', f' {labels["PL"]} '  , ' ']
+    sgpl = [f' {labels["SG"]} ', ' ', f' {labels["PL"]} ' , ' ']
     verbs.insert(0,sgpl)
-
     header = [f' {labels["number"]} ', f' {labels["person"]} ']
     header.extend([f' {labels[x]} ' if x in labels else f' {labels["unknown"]} ' for x in TVMs])
-
-
     r_verbs = rotate_lists(verbs)
     tcontent = "|" + "|".join(header) + "|\n"
     tcontent += "|" + ":----|" * len(header) + "\n"
-    tcontent += "\n".join(['|' + "|".join(x)  + '|' for x in r_verbs])
+    tcontent += "\n".join(['|' + "|".join(x) + '|' for x in r_verbs])
     print(tcontent)
     print()
 
@@ -50,14 +43,11 @@ def layout_non_merged_imp_paradigm_md(verbs, tvm, labels):
     header = [f' {labels["number"]} ',
              f' {labels["person"]} ',
              f' {labels[tvm] if tvm in labels else labels["unknown"]} ']
-    numbers = [f' {labels["SG"]} ',  ' ', f' {labels["PL"]} ' ,  ' ']
-
+    numbers = [f' {labels["SG"]} ', ' ', f' {labels["PL"]} ', ' ']
     r_verbs = rotate_lists([numbers, row_labels, v])
-    #r_verbs.insert(0, numbers)
-
     tcontent = "|" + "|".join(header) + "|\n"
     tcontent += "|:----|:----|:----|\n"
-    tcontent += "\n".join(['|' + "|".join(x)  + '|' for x in r_verbs])
+    tcontent += "\n".join(['|' + "|".join(x) + '|' for x in r_verbs])
     print(tcontent)
     print()
 
@@ -68,15 +58,12 @@ def layout_merged_verb_paradigm_md(verbs, TVMs, labels):
     verbs.insert(0,row_labels)
     sgpl = [f' {labels["SG"]} ', ' ', ' ', f' {labels["PL"]} ' , ' ' , ' ']
     verbs.insert(0,sgpl)
-
     header = [f' {labels["number"]} ', f' {labels["person"]} ']
     header.extend([f' {labels[x]} ' if x in labels else f' {labels["unknown"]} ' for x in TVMs])
-
-
     r_verbs = rotate_lists(verbs)
     tcontent = "|" + "|".join(header) + "|\n"
     tcontent += "|" + ":----|" * len(header) + "\n"
-    tcontent += "\n".join(['|' + "|".join(x)  + '|' for x in r_verbs])
+    tcontent += "\n".join(['|' + "|".join(x) + '|' for x in r_verbs])
     print(tcontent)
     print()
 
@@ -87,20 +74,16 @@ def layout_non_merged_verb_paradigm_md(verbs, tvm, labels):
              f' {labels["person"]} ',
              f' {labels[tvm] if tvm in labels else labels["unknown"]} ']
     numbers = [f' {labels["SG"]} ', ' ', ' ', f' {labels["PL"]} ' , ' ' , ' ']
-
     r_verbs = rotate_lists([numbers, row_labels, v])
-    #r_verbs.insert(0, numbers)
-
     tcontent = "|" + "|".join(header) + "|\n"
     tcontent += "|:----|:----|:----|\n"
-    tcontent += "\n".join(['|' + "|".join(x)  + '|' for x in r_verbs])
+    tcontent += "\n".join(['|' + "|".join(x) + '|' for x in r_verbs])
     print(tcontent)
     print()
 
 def layout_merged_inf_paradigm_md(forms, labels):
     print("| | " + labels["inf"] + " |")
     print("|:---|:---|")
-
     for tvm, form in forms:
         print(f'| {labels[tvm] if tvm in labels else labels["unknown"]} | {form[0]} |')
     print()
@@ -112,9 +95,7 @@ def layout_non_merged_inf_paradigm_md(form, tvm, labels):
     print()
 
 def layout_participle_summary_paradigm_md(forms, label, labels):
-
     forms = [f' {x} ' for x in forms]
-
     header = [f' {labels["number"]} ',
              f' {labels["case"]} ',
              f' {labels["masc"]} ',
@@ -128,15 +109,12 @@ def layout_participle_summary_paradigm_md(forms, label, labels):
     row1.insert(0, f' {labels["SG"]} ')
     row2.insert(0, f' {labels["gen"]} ')
     row2.insert(0, f' ')
-
     rows = [row1, row2]
     tcontent = f'| {"|".join(header)} |\n'
     tcontent += f'|:-----|:-----|:-----|:-----|:-----|\n'
     tcontent += "\n".join([f'| {"|".join(x)} |' for x in rows])
-
     print(tcontent)
     print()
-
 
 def conjugate_md(lemma, *TVMs, tags=None, labels="labels.yaml", lang="el", merge_paradigms=True):
     labels = load_labels(labels, lang)
@@ -177,15 +155,12 @@ def layout_merged_imp_paradigm_html(verbs, TVMs, labels):
     verbs = [[f'<td class="para-item">{y}</td>' for y in xs] for xs in verbs]
     row_labels = [f'<td class="para-row-label">{labels[x]}</td>' for x in ['2nd', '3rd']] * 2
     verbs.insert(0,row_labels)
-
-    header = [f'<td class="para-header-cell">{labels[x]}</td>' if x in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>' for x in TVMs ]
+    header = [f'<td class="para-header-cell">{labels[x]}</td>' if x in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>' for x in TVMs]
     header.insert(0, f'<td class="para-header-cell">{labels["person"]}</td>')
     header.insert(0, f'<td class="para-header-cell">{labels["number"]}</td>')
-
     r_verbs = rotate_lists(verbs)
     r_verbs[0].insert(0, f'<td class="para-row-label" rowspan="2" valign="top">{labels["SG"]}</td>')
     r_verbs[2].insert(0, f'<td class="para-row-label" rowspan="2" valign="top">{labels["PL"]}</td>')
-
     tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
     tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_verbs]) + "\n</tbody>"
     print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
@@ -198,13 +173,9 @@ def layout_non_merged_imp_paradigm_html(verbs, tvm, labels):
     header = [f'<td class="para-header-cell">{labels["number"]}</td>',
              f'<td class="para-header-cell">{labels["person"]}</td>',
              f'<td class="para-header-cell">{labels[tvm]}</td>' if tvm in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>']
-    #numbers = [f'<td class="para-row-label" rowspan="3" valign="top">{labels["SG"]}</td>',
-    #           f'<td class="para-row-label" rowspan="3" valign="top">{labels["PL"]}</td>']
-
     r_verbs = rotate_lists([row_labels, v])
     r_verbs[0].insert(0, f'<td class="para-row-label" rowspan="2" valign="top">{labels["SG"]}</td>')
     r_verbs[2].insert(0, f'<td class="para-row-label" rowspan="2" valign="top">{labels["PL"]}</td>')
-
     tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
     tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_verbs]) + "\n</tbody>"
     print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
@@ -214,10 +185,8 @@ def layout_non_merged_imp_paradigm_html(verbs, tvm, labels):
 def layout_merged_inf_paradigm_html(verbs, labels):
     header = [f'<td class="para-header-cell"></td>',
              f'<td class="para-header-cell">{labels["inf"]}</td>']
-
     vs = [[f'<td class="para-item">{labels[tvm] if tvm in labels else labels["unknown"]}</td>',
             f'<td class="para-item">{y[0]}</td>'] for (tvm, y) in verbs]
-
     tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
     tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in vs]) + "\n</tbody>"
     print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
@@ -227,10 +196,8 @@ def layout_merged_inf_paradigm_html(verbs, labels):
 def layout_non_merged_inf_paradigm_html(verbs, tvm, labels):
     header = [f'<td class="para-header-cell"></td>',
              f'<td class="para-header-cell">{labels["inf"]}</td>']
-
     vs = [[f'<td class="para-item">{labels[tvm] if tvm in labels else labels["unknown"]}</td>',
             f'<td class="para-item">{y}</td>'] for y in verbs]
-
     tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
     tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in vs]) + "\n</tbody>"
     print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
@@ -239,9 +206,7 @@ def layout_non_merged_inf_paradigm_html(verbs, tvm, labels):
 
 
 def layout_participle_summary_paradigm_html(forms, label, labels):
-
     forms = [f'<td class="para-item">{x}</td>' for x in forms]
-
     header = [f'<td class="para-header-cell">{labels["number"]}</td>',
              f'<td class="para-header-cell">{labels["case"]}</td>',
              f'<td class="para-header-cell">{labels["masc"]}</td>',
@@ -254,26 +219,23 @@ def layout_participle_summary_paradigm_html(forms, label, labels):
     row1.insert(0, f'<td class="para-row-label">{labels["nom"]}</td>')
     row1.insert(0, f'<td class="para-row-label" valign="top" rowspan="2">{labels["SG"]}</td>')
     row2.insert(0, f'<td class="para-row-label">{labels["gen"]}</td>')
-
     rows = [row1, row2]
     tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
     tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in rows]) + "\n</tbody>"
     print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
     print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+    print()
 
 def layout_merged_verb_paradigm_html(verbs, TVMs, labels):
     verbs = [[f'<td class="para-item">{y}</td>' for y in xs] for xs in verbs]
     row_labels = [f'<td class="para-row-label">{labels[x]}</td>' for x in ['1st', '2nd', '3rd']] * 2
     verbs.insert(0,row_labels)
-
     header = [f'<td class="para-header-cell">{labels[x]}</td>' if x in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>' for x in TVMs ]
     header.insert(0, f'<td class="para-header-cell">{labels["person"]}</td>')
     header.insert(0, f'<td class="para-header-cell">{labels["number"]}</td>')
-
     r_verbs = rotate_lists(verbs)
     r_verbs[0].insert(0, f'<td class="para-row-label" rowspan="3" valign="top">{labels["SG"]}</td>')
     r_verbs[3].insert(0, f'<td class="para-row-label" rowspan="3" valign="top">{labels["PL"]}</td>')
-
     tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
     tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_verbs]) + "\n</tbody>"
     print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
@@ -286,19 +248,14 @@ def layout_non_merged_verb_paradigm_html(verbs, tvm, labels):
     header = [f'<td class="para-header-cell">{labels["number"]}</td>',
              f'<td class="para-header-cell">{labels["person"]}</td>',
              f'<td class="para-header-cell">{labels[tvm]}</td>'if tvm in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>']
-    #numbers = [f'<td class="para-row-label" rowspan="3" valign="top">{labels["SG"]}</td>',
-    #           f'<td class="para-row-label" rowspan="3" valign="top">{labels["PL"]}</td>']
-
     r_verbs = rotate_lists([row_labels, v])
     r_verbs[0].insert(0, f'<td class="para-row-label" rowspan="3" valign="top">{labels["SG"]}</td>')
     r_verbs[3].insert(0, f'<td class="para-row-label" rowspan="3" valign="top">{labels["PL"]}</td>')
-
     tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
     tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_verbs]) + "\n</tbody>"
     print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
     print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
     print()
-
 
 def conjugate_html(lemma, *TVMs, tags=None, labels="labels.yaml", lang="el", merge_paradigms=True):
     labels = load_labels(labels, lang)
@@ -308,8 +265,6 @@ def conjugate_html(lemma, *TVMs, tags=None, labels="labels.yaml", lang="el", mer
     imps = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "D"]
     infs = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "N"]
     parts = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "P"]
-    #[('PAD', {'PAD.2S': 'λῦε', 'PAD.3S': 'λῡέτω', 'PAD.2P': 'λῡ́ετε', 'PAD.3P': 'λῡόντων'})]
-    #[('PAN', {'PAN': 'λῡ́ειν'})]
     if verbs:
         if merge_paradigms:
             tvms = [x[0] for x in verbs]
@@ -328,7 +283,6 @@ def conjugate_html(lemma, *TVMs, tags=None, labels="labels.yaml", lang="el", mer
                 layout_non_merged_imp_paradigm_html(v, label, labels)
     if infs:
         if merge_paradigms:
-
             layout_merged_inf_paradigm_html(infs, labels)
         else:
             for label, v in infs:
@@ -337,10 +291,8 @@ def conjugate_html(lemma, *TVMs, tags=None, labels="labels.yaml", lang="el", mer
         for label, v in parts:
             layout_participle_summary_paradigm_html(v, label, labels)
 
-
 def layout_nouny_paradigm_md(forms, labels):
     forms = [[f" {y} " for y in x] for x in forms]
-
     header = [f' {labels["number"]} ',
              f' {labels["case"]} ',
              f' {labels["masc"]} ',
@@ -352,11 +304,9 @@ def layout_nouny_paradigm_md(forms, labels):
                f' {labels["acc"]} ',
                f' {labels["voc"]} '] * 2
     forms.insert(0, cases)
-
     numbers = [f' {labels["SG"]} ', ' ', ' ',' ',' ', f' {labels["PL"]} ' , ' ' , ' ', ' ', ' ']
     forms.insert(0, numbers)
     r_forms = rotate_lists(forms)
-
     tcontent = f'| {"|".join(header)} |\n'
     tcontent += "|:----|:----|:----|:----|:----|\n"
     tcontent += "\n".join([f'|{"|".join(x)}|' for x in r_forms])
@@ -370,7 +320,6 @@ def decline_md(lemma, TVM, tags=None, labels="labels.yaml", lang="el"):
 
 def layout_nouny_paradigm_html(forms, labels):
     forms = [[f'<td class="para-item">{y}</td>' for y in x] for x in forms]
-
     header = [f'<td class="para-header-cell">{labels["number"]}</td>',
              f'<td class="para-header-cell">{labels["case"]}</td>',
              f'<td class="para-header-cell">{labels["masc"]}</td>',
@@ -382,15 +331,14 @@ def layout_nouny_paradigm_html(forms, labels):
                f'<td class="para-row-label">{labels["acc"]}</td>',
                f'<td class="para-row-label">{labels["voc"]}</td>'] * 2
     forms.insert(0, cases)
-
     r_forms = rotate_lists(forms)
     r_forms[0].insert(0, f'<td class="para-row-label" rowspan="5" valign="top">{labels["SG"]}</td>')
     r_forms[5].insert(0, f'<td class="para-row-label" rowspan="5" valign="top">{labels["PL"]}</td>')
-
     tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
     tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_forms]) + "\n</tbody>"
     print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
     print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+    print()
 
 def decline_html(lemma, TVM, tags=None, labels="labels.yaml", lang="el"):
     labels = load_labels(labels, lang)

--- a/paradigm_tools.py
+++ b/paradigm_tools.py
@@ -1,0 +1,398 @@
+# py -m doctest -v examples.rst
+from greek_inflexion import GreekInflexion
+import pprint
+
+
+
+from yaml import load, dump
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+inflexion = GreekInflexion('stemming.yaml', 'STEM_DATA/pratt_lexicon.yaml')
+
+def rotate_lists(xs):
+    len_x0 = len(xs[0])
+    for x in xs:
+        assert len(x) == len_x0
+    out = []
+    for i in range(0,len(xs[0])):
+        out.append([x[i] for x in xs])
+    return out
+
+def load_labels(fpath, lang):
+    with open(fpath, 'r', encoding="UTF-8") as f:
+        labels = load(f, Loader=Loader)
+        return labels[lang]
+
+def layout_merged_imp_paradigm_md(verbs, TVMs, labels):
+    verbs = [[f' {y} ' for y in xs] for xs in verbs]
+    row_labels = [f' {labels[x]} ' for x in ['2nd', '3rd']] * 2
+    verbs.insert(0,row_labels)
+    sgpl = [f' {labels["SG"]} ',  ' ', f' {labels["PL"]} '  , ' ']
+    verbs.insert(0,sgpl)
+
+    header = [f' {labels["number"]} ', f' {labels["person"]} ']
+    header.extend([f' {labels[x]} ' if x in labels else f' {labels["unknown"]} ' for x in TVMs])
+
+
+    r_verbs = rotate_lists(verbs)
+    tcontent = "|" + "|".join(header) + "|\n"
+    tcontent += "|" + ":----|" * len(header) + "\n"
+    tcontent += "\n".join(['|' + "|".join(x)  + '|' for x in r_verbs])
+    print(tcontent)
+    print()
+
+def layout_non_merged_imp_paradigm_md(verbs, tvm, labels):
+    row_labels = [f' {labels[x]} ' for x in ['2nd', '3rd']] * 2
+    v = [f' {y} ' for y in verbs]
+    header = [f' {labels["number"]} ',
+             f' {labels["person"]} ',
+             f' {labels[tvm] if tvm in labels else labels["unknown"]} ']
+    numbers = [f' {labels["SG"]} ',  ' ', f' {labels["PL"]} ' ,  ' ']
+
+    r_verbs = rotate_lists([numbers, row_labels, v])
+    #r_verbs.insert(0, numbers)
+
+    tcontent = "|" + "|".join(header) + "|\n"
+    tcontent += "|:----|:----|:----|\n"
+    tcontent += "\n".join(['|' + "|".join(x)  + '|' for x in r_verbs])
+    print(tcontent)
+    print()
+
+
+def layout_merged_verb_paradigm_md(verbs, TVMs, labels):
+    verbs = [[f' {y} ' for y in xs] for xs in verbs]
+    row_labels = [f' {labels[x]} ' for x in ['1st', '2nd', '3rd']] * 2
+    verbs.insert(0,row_labels)
+    sgpl = [f' {labels["SG"]} ', ' ', ' ', f' {labels["PL"]} ' , ' ' , ' ']
+    verbs.insert(0,sgpl)
+
+    header = [f' {labels["number"]} ', f' {labels["person"]} ']
+    header.extend([f' {labels[x]} ' if x in labels else f' {labels["unknown"]} ' for x in TVMs])
+
+
+    r_verbs = rotate_lists(verbs)
+    tcontent = "|" + "|".join(header) + "|\n"
+    tcontent += "|" + ":----|" * len(header) + "\n"
+    tcontent += "\n".join(['|' + "|".join(x)  + '|' for x in r_verbs])
+    print(tcontent)
+    print()
+
+def layout_non_merged_verb_paradigm_md(verbs, tvm, labels):
+    row_labels = [f' {labels[x]} ' for x in ['1st', '2nd', '3rd']] * 2
+    v = [f' {y} ' for y in verbs]
+    header = [f' {labels["number"]} ',
+             f' {labels["person"]} ',
+             f' {labels[tvm] if tvm in labels else labels["unknown"]} ']
+    numbers = [f' {labels["SG"]} ', ' ', ' ', f' {labels["PL"]} ' , ' ' , ' ']
+
+    r_verbs = rotate_lists([numbers, row_labels, v])
+    #r_verbs.insert(0, numbers)
+
+    tcontent = "|" + "|".join(header) + "|\n"
+    tcontent += "|:----|:----|:----|\n"
+    tcontent += "\n".join(['|' + "|".join(x)  + '|' for x in r_verbs])
+    print(tcontent)
+    print()
+
+def layout_merged_inf_paradigm_md(forms, labels):
+    print("| | " + labels["inf"] + " |")
+    print("|:---|:---|")
+
+    for tvm, form in forms:
+        print(f'| {labels[tvm] if tvm in labels else labels["unknown"]} | {form[0]} |')
+    print()
+
+def layout_non_merged_inf_paradigm_md(form, tvm, labels):
+    print("| | " + labels["inf"] + " |")
+    print("|:---|:---|")
+    print(f'| {labels[tvm] if tvm in labels else labels["unknown"]} | {form[0]} |')
+    print()
+
+def layout_participle_summary_paradigm_md(forms, label, labels):
+
+    forms = [f' {x} ' for x in forms]
+
+    header = [f' {labels["number"]} ',
+             f' {labels["case"]} ',
+             f' {labels["masc"]} ',
+             f' {labels["fem"]} ',
+             f' {labels["neut"]} ']
+    cases =  [f' {labels["nom"]} ',
+               f' {labels["gen"]} '] * 2
+    row1 = forms[0:3]
+    row2 = forms[3:]
+    row1.insert(0, f' {labels["nom"]} ')
+    row1.insert(0, f' {labels["SG"]} ')
+    row2.insert(0, f' {labels["gen"]} ')
+    row2.insert(0, f' ')
+
+    rows = [row1, row2]
+    tcontent = f'| {"|".join(header)} |\n'
+    tcontent += f'|:-----|:-----|:-----|:-----|:-----|\n'
+    tcontent += "\n".join([f'| {"|".join(x)} |' for x in rows])
+
+    print(tcontent)
+    print()
+
+
+def conjugate_md(lemma, *TVMs, tags=None, labels="labels.yaml", lang="el", merge_paradigms=True):
+    labels = load_labels(labels, lang)
+    forms = inflexion.conjugate_core(lemma, *TVMs, tags=tags)
+    # participles can't be merged with other verb paradigms
+    verbs = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] in "SOI"]
+    imps = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "D"]
+    infs = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "N"]
+    parts = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "P"]
+    if verbs:
+        if merge_paradigms:
+            tvms = [x[0] for x in verbs]
+            verbs = [x[1] for x in verbs]
+            layout_merged_verb_paradigm_md(verbs, tvms, labels)
+        else:
+            for label, v in verbs:
+                layout_non_merged_verb_paradigm_md(v, label, labels)
+    if infs:
+        if merge_paradigms:
+            layout_merged_inf_paradigm_md(infs, labels)
+        else:
+            for label, v in infs:
+                layout_non_merged_inf_paradigm_md(v, label, labels)
+    if imps:
+        if merge_paradigms:
+            tvms = [x[0] for x in imps]
+            imps = [x[1] for x in imps]
+            layout_merged_imp_paradigm_md(imps, tvms, labels)
+        else:
+            for label, v in imps:
+                layout_non_merged_imp_paradigm_md(v, label, labels)
+    if parts:
+        for label, v in parts:
+            layout_participle_summary_paradigm_md(v, label, labels)
+
+
+def layout_merged_imp_paradigm_html(verbs, TVMs, labels):
+    verbs = [[f'<td class="para-item">{y}</td>' for y in xs] for xs in verbs]
+    row_labels = [f'<td class="para-row-label">{labels[x]}</td>' for x in ['2nd', '3rd']] * 2
+    verbs.insert(0,row_labels)
+
+    header = [f'<td class="para-header-cell">{labels[x]}</td>' if x in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>' for x in TVMs ]
+    header.insert(0, f'<td class="para-header-cell">{labels["person"]}</td>')
+    header.insert(0, f'<td class="para-header-cell">{labels["number"]}</td>')
+
+    r_verbs = rotate_lists(verbs)
+    r_verbs[0].insert(0, f'<td class="para-row-label" rowspan="2" valign="top">{labels["SG"]}</td>')
+    r_verbs[2].insert(0, f'<td class="para-row-label" rowspan="2" valign="top">{labels["PL"]}</td>')
+
+    tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
+    tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_verbs]) + "\n</tbody>"
+    print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
+    print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+    print()
+
+def layout_non_merged_imp_paradigm_html(verbs, tvm, labels):
+    row_labels = [f'<td class="para-row-label">{labels[x]}</td>' for x in ['2nd', '3rd']] * 2
+    v = [f'<td class="para-item">{y}</td>' for y in verbs]
+    header = [f'<td class="para-header-cell">{labels["number"]}</td>',
+             f'<td class="para-header-cell">{labels["person"]}</td>',
+             f'<td class="para-header-cell">{labels[tvm]}</td>' if tvm in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>']
+    #numbers = [f'<td class="para-row-label" rowspan="3" valign="top">{labels["SG"]}</td>',
+    #           f'<td class="para-row-label" rowspan="3" valign="top">{labels["PL"]}</td>']
+
+    r_verbs = rotate_lists([row_labels, v])
+    r_verbs[0].insert(0, f'<td class="para-row-label" rowspan="2" valign="top">{labels["SG"]}</td>')
+    r_verbs[2].insert(0, f'<td class="para-row-label" rowspan="2" valign="top">{labels["PL"]}</td>')
+
+    tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
+    tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_verbs]) + "\n</tbody>"
+    print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
+    print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+    print()
+
+def layout_merged_inf_paradigm_html(verbs, labels):
+    header = [f'<td class="para-header-cell"></td>',
+             f'<td class="para-header-cell">{labels["inf"]}</td>']
+
+    vs = [[f'<td class="para-item">{labels[tvm] if tvm in labels else labels["unknown"]}</td>',
+            f'<td class="para-item">{y[0]}</td>'] for (tvm, y) in verbs]
+
+    tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
+    tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in vs]) + "\n</tbody>"
+    print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
+    print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+    print()
+
+def layout_non_merged_inf_paradigm_html(verbs, tvm, labels):
+    header = [f'<td class="para-header-cell"></td>',
+             f'<td class="para-header-cell">{labels["inf"]}</td>']
+
+    vs = [[f'<td class="para-item">{labels[tvm] if tvm in labels else labels["unknown"]}</td>',
+            f'<td class="para-item">{y}</td>'] for y in verbs]
+
+    tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
+    tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in vs]) + "\n</tbody>"
+    print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
+    print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+    print()
+
+
+def layout_participle_summary_paradigm_html(forms, label, labels):
+
+    forms = [f'<td class="para-item">{x}</td>' for x in forms]
+
+    header = [f'<td class="para-header-cell">{labels["number"]}</td>',
+             f'<td class="para-header-cell">{labels["case"]}</td>',
+             f'<td class="para-header-cell">{labels["masc"]}</td>',
+             f'<td class="para-header-cell">{labels["fem"]}</td>',
+             f'<td class="para-header-cell">{labels["neut"]}</td>']
+    cases =  [f'<td class="para-row-label">{labels["nom"]}</td>',
+               f'<td class="para-row-label">{labels["gen"]}</td>'] * 2
+    row1 = forms[0:3]
+    row2 = forms[3:]
+    row1.insert(0, f'<td class="para-row-label">{labels["nom"]}</td>')
+    row1.insert(0, f'<td class="para-row-label" valign="top" rowspan="2">{labels["SG"]}</td>')
+    row2.insert(0, f'<td class="para-row-label">{labels["gen"]}</td>')
+
+    rows = [row1, row2]
+    tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
+    tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in rows]) + "\n</tbody>"
+    print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
+    print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+
+def layout_merged_verb_paradigm_html(verbs, TVMs, labels):
+    verbs = [[f'<td class="para-item">{y}</td>' for y in xs] for xs in verbs]
+    row_labels = [f'<td class="para-row-label">{labels[x]}</td>' for x in ['1st', '2nd', '3rd']] * 2
+    verbs.insert(0,row_labels)
+
+    header = [f'<td class="para-header-cell">{labels[x]}</td>' if x in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>' for x in TVMs ]
+    header.insert(0, f'<td class="para-header-cell">{labels["person"]}</td>')
+    header.insert(0, f'<td class="para-header-cell">{labels["number"]}</td>')
+
+    r_verbs = rotate_lists(verbs)
+    r_verbs[0].insert(0, f'<td class="para-row-label" rowspan="3" valign="top">{labels["SG"]}</td>')
+    r_verbs[3].insert(0, f'<td class="para-row-label" rowspan="3" valign="top">{labels["PL"]}</td>')
+
+    tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
+    tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_verbs]) + "\n</tbody>"
+    print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
+    print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+    print()
+
+def layout_non_merged_verb_paradigm_html(verbs, tvm, labels):
+    row_labels = [f'<td class="para-row-label">{labels[x]}</td>' for x in ['1st', '2nd', '3rd']] * 2
+    v = [f'<td class="para-item">{y}</td>' for y in verbs]
+    header = [f'<td class="para-header-cell">{labels["number"]}</td>',
+             f'<td class="para-header-cell">{labels["person"]}</td>',
+             f'<td class="para-header-cell">{labels[tvm]}</td>'if tvm in labels else f'<td class="para-header-cell">{labels["unknown"]}</td>']
+    #numbers = [f'<td class="para-row-label" rowspan="3" valign="top">{labels["SG"]}</td>',
+    #           f'<td class="para-row-label" rowspan="3" valign="top">{labels["PL"]}</td>']
+
+    r_verbs = rotate_lists([row_labels, v])
+    r_verbs[0].insert(0, f'<td class="para-row-label" rowspan="3" valign="top">{labels["SG"]}</td>')
+    r_verbs[3].insert(0, f'<td class="para-row-label" rowspan="3" valign="top">{labels["PL"]}</td>')
+
+    tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
+    tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_verbs]) + "\n</tbody>"
+    print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
+    print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+    print()
+
+
+def conjugate_html(lemma, *TVMs, tags=None, labels="labels.yaml", lang="el", merge_paradigms=True):
+    labels = load_labels(labels, lang)
+    forms = inflexion.conjugate_core(lemma, *TVMs, tags=tags)
+    # participles can't be merged with other verb paradigms
+    verbs = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] in "IOS"]
+    imps = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "D"]
+    infs = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "N"]
+    parts = [(fs[0], list(fs[1].values())) for fs in forms if fs[0][2] == "P"]
+    #[('PAD', {'PAD.2S': 'λῦε', 'PAD.3S': 'λῡέτω', 'PAD.2P': 'λῡ́ετε', 'PAD.3P': 'λῡόντων'})]
+    #[('PAN', {'PAN': 'λῡ́ειν'})]
+    if verbs:
+        if merge_paradigms:
+            tvms = [x[0] for x in verbs]
+            verbs = [x[1] for x in verbs]
+            layout_merged_verb_paradigm_html(verbs, tvms, labels)
+        else:
+            for label, v in verbs:
+                layout_non_merged_verb_paradigm_html(v, label, labels)
+    if imps:
+        if merge_paradigms:
+            tvms = [x[0] for x in imps]
+            imps = [x[1] for x in imps]
+            layout_merged_imp_paradigm_html(imps, tvms, labels)
+        else:
+            for label, v in imps:
+                layout_non_merged_imp_paradigm_html(v, label, labels)
+    if infs:
+        if merge_paradigms:
+
+            layout_merged_inf_paradigm_html(infs, labels)
+        else:
+            for label, v in infs:
+                layout_non_merged_inf_paradigm_html(v, label, labels)
+    if parts:
+        for label, v in parts:
+            layout_participle_summary_paradigm_html(v, label, labels)
+
+
+def layout_nouny_paradigm_md(forms, labels):
+    forms = [[f" {y} " for y in x] for x in forms]
+
+    header = [f' {labels["number"]} ',
+             f' {labels["case"]} ',
+             f' {labels["masc"]} ',
+             f' {labels["fem"]} ',
+             f' {labels["neut"]} ']
+    cases =  [f' {labels["nom"]} ',
+               f' {labels["gen"]} ',
+               f' {labels["dat"]} ',
+               f' {labels["acc"]} ',
+               f' {labels["voc"]} '] * 2
+    forms.insert(0, cases)
+
+    numbers = [f' {labels["SG"]} ', ' ', ' ',' ',' ', f' {labels["PL"]} ' , ' ' , ' ', ' ', ' ']
+    forms.insert(0, numbers)
+    r_forms = rotate_lists(forms)
+
+    tcontent = f'| {"|".join(header)} |\n'
+    tcontent += "|:----|:----|:----|:----|:----|\n"
+    tcontent += "\n".join([f'|{"|".join(x)}|' for x in r_forms])
+    print(tcontent)
+    print()
+
+def decline_md(lemma, TVM, tags=None, labels="labels.yaml", lang="el"):
+    labels = load_labels(labels, lang)
+    forms = [list(x.values()) for x in inflexion.decline_core(lemma, TVM, tags=tags)]
+    layout_nouny_paradigm_md(forms, labels)
+
+def layout_nouny_paradigm_html(forms, labels):
+    forms = [[f'<td class="para-item">{y}</td>' for y in x] for x in forms]
+
+    header = [f'<td class="para-header-cell">{labels["number"]}</td>',
+             f'<td class="para-header-cell">{labels["case"]}</td>',
+             f'<td class="para-header-cell">{labels["masc"]}</td>',
+             f'<td class="para-header-cell">{labels["fem"]}</td>',
+             f'<td class="para-header-cell">{labels["neut"]}</td>']
+    cases =  [f'<td class="para-row-label">{labels["nom"]}</td>',
+               f'<td class="para-row-label">{labels["gen"]}</td>',
+               f'<td class="para-row-label">{labels["dat"]}</td>',
+               f'<td class="para-row-label">{labels["acc"]}</td>',
+               f'<td class="para-row-label">{labels["voc"]}</td>'] * 2
+    forms.insert(0, cases)
+
+    r_forms = rotate_lists(forms)
+    r_forms[0].insert(0, f'<td class="para-row-label" rowspan="5" valign="top">{labels["SG"]}</td>')
+    r_forms[5].insert(0, f'<td class="para-row-label" rowspan="5" valign="top">{labels["PL"]}</td>')
+
+    tcontent = f'<thead><tr class="para-header-row">{"".join(header)}</tr></thead>'
+    tcontent += "<tbody>\n" + "\n".join([f'<tr>{"".join(x)}</tr>' for x in r_forms]) + "\n</tbody>"
+    print("<link href=\"./paradigm.css\" rel=\"stylesheet\">")
+    print(f'<table class="verb-paradigm">\n{tcontent}\n</table>')
+
+def decline_html(lemma, TVM, tags=None, labels="labels.yaml", lang="el"):
+    labels = load_labels(labels, lang)
+    forms = [list(x.values()) for x in inflexion.decline_core(lemma, TVM, tags=tags)]
+    layout_nouny_paradigm_html(forms, labels)

--- a/table_test.html
+++ b/table_test.html
@@ -1,8 +1,12 @@
 <link href="./paradigm.css" rel="stylesheet">
 <table class="verb-paradigm">
-<thead><tr class="para-header-row"><td class="para-header-cell"></td><td class="para-header-cell">ἀπαρέμφατος</td></tr></thead><tbody>
-<tr><td class="para-item">ἐνεστώς ἐνεργητικόν</td><td class="para-item">λῡ́ειν</td></tr>
-<tr><td class="para-item">ἀόριστος ἐνεργητικόν</td><td class="para-item">λῦσαι</td></tr>
+<thead><tr class="para-header-row"><td class="para-header-cell">ἀριθμός</td><td class="para-header-cell">πρώσοπον</td><td class="para-header-cell">ἐνεστώς ἐνεργητικόν ὁριστική</td><td class="para-header-cell">ἀόριστος ἐνεργητικόν ὁριστική</td></tr></thead><tbody>
+<tr><td class="para-row-label" rowspan="3" valign="top">ἑνικόν</td><td class="para-row-label">πρῶτον</td><td class="para-item">λῡ́ω</td><td class="para-item">ἔλυσα</td></tr>
+<tr><td class="para-row-label">δευτέρον</td><td class="para-item">λῡ́εις</td><td class="para-item">ἔλυσας</td></tr>
+<tr><td class="para-row-label">τρίτον</td><td class="para-item">λῡ́ει</td><td class="para-item">ἔλυσε(ν)</td></tr>
+<tr><td class="para-row-label" rowspan="3" valign="top">πληθυντικόν</td><td class="para-row-label">πρῶτον</td><td class="para-item">λῡ́ομεν</td><td class="para-item">ἐλύσαμεν</td></tr>
+<tr><td class="para-row-label">δευτέρον</td><td class="para-item">λῡ́ετε</td><td class="para-item">ἐλύσατε</td></tr>
+<tr><td class="para-row-label">τρίτον</td><td class="para-item">λῡ́ουσι(ν)</td><td class="para-item">ἔλυσαν</td></tr>
 </tbody>
 </table>
 

--- a/table_test.html
+++ b/table_test.html
@@ -1,0 +1,8 @@
+<link href="./paradigm.css" rel="stylesheet">
+<table class="verb-paradigm">
+<thead><tr class="para-header-row"><td class="para-header-cell"></td><td class="para-header-cell">ἀπαρέμφατος</td></tr></thead><tbody>
+<tr><td class="para-item">ἐνεστώς ἐνεργητικόν</td><td class="para-item">λῡ́ειν</td></tr>
+<tr><td class="para-item">ἀόριστος ἐνεργητικόν</td><td class="para-item">λῦσαι</td></tr>
+</tbody>
+</table>
+

--- a/test_inflection.py
+++ b/test_inflection.py
@@ -1,0 +1,34 @@
+from greek_inflexion import GreekInflexion
+import pprint
+
+inflexion = GreekInflexion('stemming.yaml', 'STEM_DATA/pratt_lexicon.yaml')
+
+
+import paradigm_tools as pu
+
+#print(inflexion.conjugate_core("λύω", "PAI", "AAI", tags={"final-nu-aai.3s"}))
+
+#print()
+
+labels = pu.load_labels("labels.yaml", "el")
+
+#pu.decline_html("λύω", "PAP")
+#pu.decline_md("λύω", "PAP")
+
+#pu.conjugate_html("λύω", "PAD", "AAD", tags={"final-nu-aai.3s"}, merge_paradigms=False)
+pu.conjugate_html("λύω", "PAN", "AAN", tags={"final-nu-aai.3s"})
+
+
+exit()
+
+pu.conjugate_html("λύω", "PAI", "PMI", "FAI", "FMI", tags={"final-nu-aai.3s"})
+
+pu.conjugate_html("λύω", "PAI", "PMI", tags={"final-nu-aai.3s"}, merge_paradigms=False)
+
+pu.layout_merged_verb_paradigm_html([["1", "2", "3", "4", "5", "6"]], ["Random"], labels)
+
+pu.layout_merged_verb_paradigm_md([["1", "2", "3", "4", "5", "6"]], ["Random"], labels)
+
+pu.layout_non_merged_verb_paradigm_md(["1", "2", "3", "4", "5", "6"], "Random", labels)
+pu.conjugate_md("λύω", "PAI", "PMI", tags={"final-nu-aai.3s"}, merge_paradigms=True)
+pu.conjugate_md("λύω", "PAI", "PMI", tags={"final-nu-aai.3s"}, merge_paradigms=False)

--- a/test_inflection.py
+++ b/test_inflection.py
@@ -16,7 +16,7 @@ labels = pu.load_labels("labels.yaml", "el")
 #pu.decline_md("λύω", "PAP")
 
 #pu.conjugate_html("λύω", "PAD", "AAD", tags={"final-nu-aai.3s"}, merge_paradigms=False)
-pu.conjugate_html("λύω", "PAN", "AAN", tags={"final-nu-aai.3s"})
+pu.conjugate_html("λύω", "PAI", "AAI", tags={"final-nu-aai.3s"})
 
 
 exit()


### PR DESCRIPTION
I adding `conjugate_core` and `decline_core` to greek_inflexion.py. These two find the forms and return a dictionary. `paradigm_tools.py` loads `greek_inflexion` and then uses these two functions to do it's magic. I also updated `examples.rst` to run some of the paradigm layout functions so people could see how they work. Finally there is `labels.yaml` which is where users can define what they want the paradigm labels to be and `paradigms.css` which allows users to customize the html paradigms.